### PR TITLE
--showlink update?

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@ puush-linux
 
 A Bash script for uploading files to puush.me from Linux. Many thanks to @Westie for his insights on puush's undocumented API :)
 
+Update with `--showlink` by wessles.
+
 Using
 -----
 
-* Get curl if you don't have it already. Most package managers have it as `curl` (apt-get install curl, yum install curl), or check this page: http://curl.haxx.se/download.html
-* Get puush from here: https://github.com/blha303/puush-linux/raw/master/puush
-* Copy 'puush' to /usr/local/bin, and use `chmod +x /usr/local/bin/puush`.
-* Use it with `puush file.name`. 
+* Get `curl` if you don't have it already. Most package managers have it as `curl` (apt-get install curl, yum install curl), or check this page: http://curl.haxx.se/download.html
+* Get `zenity` as well.
+* Copy the 'puush' script to /usr/local/bin, and use `chmod +x /usr/local/bin/puush` to make it runnable.
+* Use it with `puush file.name`. You can also use the `--showlink` flag to open a window containing the puush link to the file after upload.
 
 You'll need to set up an environment variable, PUUSH_API_KEY. You can do this per-session with `export PUUSH_API_KEY="apiKeyHere"`, or by putting that command in `~/.bashrc`.

--- a/puush
+++ b/puush
@@ -1,7 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 
-# Uncommend following line if you would like to add api key in this file
-#PUUSH_API_KEY="apikeyhere"
+# Uncomment following line if you would like to add api key in this file
+# PUUSH_API_KEY="apikeyhere"
+# It is recommended that you instead set PUUSH_API_KEY as an environment variable in some startup script, like so:
+# PUUSH_API_KEY="xxxxxxxxxxxxxxxxxxx"; export PUUSH_API_KEY
 
 if [ -z "$PUUSH_API_KEY" ]
 then
@@ -17,4 +19,13 @@ then
   exit 3
 fi
 
-curl "https://puush.me/api/up" -# -F "k=$PUUSH_API_KEY" -F "z=poop" -F "f=@$1" | sed -E 's/^.+,(.+),.+,.+$/\1\n/'
+# If we are supposed to show a link (--showlink), then pop up a dialog with it.
+if [[ $* == *--showlink* ]]
+then
+  curl "https://puush.me/api/up" -# -F "k=$PUUSH_API_KEY" -F "z=poop" -F "f=@$1" | sed -E 's/^.+,(.+),.+,.+$/\1\n/' >> /tmp/puushlink
+  zenity --info --text="`cat /tmp/puushlink`"
+  rm /tmp/puushlink
+# Else, upload like normal
+else
+  curl "https://puush.me/api/up" -# -F "k=$PUUSH_API_KEY" -F "z=poop" -F "f=@$1" | sed -E 's/^.+,(.+),.+,.+$/\1\n/'
+fi

--- a/puush
+++ b/puush
@@ -25,7 +25,6 @@ then
   curl "https://puush.me/api/up" -# -F "k=$PUUSH_API_KEY" -F "z=poop" -F "f=@$1" | sed -E 's/^.+,(.+),.+,.+$/\1\n/' >> /tmp/puushlink
   zenity --info --text="`cat /tmp/puushlink`"
   rm /tmp/puushlink
-# Else, upload like normal
 else
   curl "https://puush.me/api/up" -# -F "k=$PUUSH_API_KEY" -F "z=poop" -F "f=@$1" | sed -E 's/^.+,(.+),.+,.+$/\1\n/'
 fi


### PR DESCRIPTION
I kept making this update manually whenever I installed puush-linux. It allows you to see the link you made right after uploading using zenity. It's convenient for keyboard shortcuts using puush.

Example:

![img](https://cloud.githubusercontent.com/assets/4768957/8510070/eae82db4-229b-11e5-84f6-8bde57a642a3.png)
