### PR TITLE
Added information about hash parameter to API doc.

### DIFF
--- a/apiDocumentation.md
+++ b/apiDocumentation.md
@@ -42,6 +42,8 @@ puush API documentation
     - k = apikey
     - z = anything at all
     - f = file
+    - c = MD5 hash of file (optional, will only be used if present in the request)
  - Response (upload, success): `0,{url},{id},{size}`
  - Response (failure, upload): `-1`
  - Response (failure, no filename header): `-2`
+ - Response (failure, hash didn't match): `-3`


### PR DESCRIPTION
Well, uh, to be honest I feel a bit silly making a third pull request, but I discovered yet another new thing.

When uploading files, a `c` parameter can (but doesn't have to) be added with the lower-case MD5 hash of the file as value. This will then be used to validate the file, and return yet another new error code if it doesn't match.